### PR TITLE
features/138 change password for registered user user settings

### DIFF
--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -158,6 +158,7 @@ public class SecurityConfig {
                                 "/user/shopping-list-items",
                                 "/user/{userId}/habit",
                                 "/ownSecurity/set-password",
+                                "/ownSecurity/reset-password",
                                 "/email/sendReport",
                                 "/email/addEcoNews",
                                 "/email/changePlaceStatus",

--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -1,21 +1,7 @@
 package greencity.exception.handler;
 
 import greencity.constant.AppConstant;
-import greencity.exception.exceptions.BadRefreshTokenException;
-import greencity.exception.exceptions.BadRequestException;
-import greencity.exception.exceptions.BadSocialNetworkLinksException;
-import greencity.exception.exceptions.BadUpdateRequestException;
-import greencity.exception.exceptions.BadUserStatusException;
-import greencity.exception.exceptions.BadVerifyEmailTokenException;
-import greencity.exception.exceptions.EmailNotVerified;
-import greencity.exception.exceptions.InvalidURLException;
-import greencity.exception.exceptions.NotFoundException;
-import greencity.exception.exceptions.PasswordsDoNotMatchesException;
-import greencity.exception.exceptions.UserAlreadyHasPasswordException;
-import greencity.exception.exceptions.UserAlreadyRegisteredException;
-import greencity.exception.exceptions.WrongEmailException;
-import greencity.exception.exceptions.WrongIdException;
-import greencity.exception.exceptions.WrongPasswordException;
+import greencity.exception.exceptions.*;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import java.util.Collections;
@@ -243,6 +229,18 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
         log.trace(ex.getMessage(), ex);
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse);
     }
+
+
+    @ExceptionHandler(PasswordSameAsOldException.class)
+    public final ResponseEntity<Object> handlePasswordSameAsOldException(
+            PasswordSameAsOldException exception,
+            WebRequest request) {
+        log.info(exception.getMessage());
+        ExceptionResponse exceptionResponse = new ExceptionResponse(getErrorAttributes(request));
+        exceptionResponse.setMessage(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exceptionResponse);
+    }
+
 
     /**
      * Method interceptor exception {@link WrongPasswordException}.

--- a/core/src/main/java/greencity/security/controller/OwnSecurityController.java
+++ b/core/src/main/java/greencity/security/controller/OwnSecurityController.java
@@ -28,8 +28,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.Locale;
 import java.util.Optional;
+
 import static greencity.constant.ErrorMessage.*;
 import static greencity.constant.ValidationConstants.USER_CREATED;
 
@@ -190,7 +192,7 @@ public class OwnSecurityController {
         @ApiResponse(responseCode = "400", description = PASSWORD_DOES_NOT_MATCH)
     })
     @PostMapping("/updatePassword")
-    public ResponseEntity<Object> changePassword(@Valid @RequestBody OwnRestoreDto form) {
+    public ResponseEntity<Object> resetPassword(@Valid @RequestBody OwnRestoreDto form) {
         passwordRecoveryService.updatePasswordUsingToken(form);
         return ResponseEntity.ok().build();
     }
@@ -273,5 +275,23 @@ public class OwnSecurityController {
         String email = authentication.getName();
         service.setPassword(dto, email);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+
+    @Operation(summary = "Reset password for user.")
+    @ResponseStatus(value = HttpStatus.OK)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+            @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+            @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
+    })
+    @PostMapping("/reset-password")
+    public ResponseEntity<Object> resetPassword(@Valid @RequestBody ResetPasswordDto dto) {
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        service.resetPassword(dto, email);
+        return ResponseEntity.status(HttpStatus.OK).build();
+
     }
 }

--- a/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
+++ b/core/src/test/java/greencity/exception/handler/CustomExceptionHandlerTest.java
@@ -1,16 +1,8 @@
 package greencity.exception.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import greencity.exception.exceptions.BadRequestException;
-import greencity.exception.exceptions.BadSocialNetworkLinksException;
-import greencity.exception.exceptions.BadUserStatusException;
-import greencity.exception.exceptions.EmailNotVerified;
-import greencity.exception.exceptions.InvalidURLException;
-import greencity.exception.exceptions.NotFoundException;
-import greencity.exception.exceptions.UserAlreadyRegisteredException;
-import greencity.exception.exceptions.WrongEmailException;
-import greencity.exception.exceptions.WrongIdException;
-import greencity.exception.exceptions.WrongPasswordException;
+import greencity.exception.exceptions.*;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -104,6 +96,24 @@ class CustomExceptionHandlerTest {
             any(ErrorAttributeOptions.class))).thenReturn(objectMap);
         assertEquals(customExceptionHandler.handleEmailNotVerified(emailNotVerified, webRequest),
             ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse));
+    }
+
+    @Test
+    void handlePasswordSameAsOldExceptionTest() {
+        String expectedErrorMessage = "testMessage";
+        HttpStatus expectedHttpStatus = HttpStatus.BAD_REQUEST;
+        PasswordSameAsOldException passwordSameAsOldException = new PasswordSameAsOldException(expectedErrorMessage);
+        objectMap.put("message", expectedErrorMessage);
+        ExceptionResponse expectedResponse = new ExceptionResponse(objectMap);
+
+        when(errorAttributes.getErrorAttributes(eq(webRequest),
+                any(ErrorAttributeOptions.class))).thenReturn(objectMap);
+
+        ResponseEntity<Object> actualResponse =
+                customExceptionHandler.handlePasswordSameAsOldException(passwordSameAsOldException, webRequest);
+
+        assertEquals(expectedHttpStatus, actualResponse.getStatusCode());
+        assertEquals(expectedResponse, actualResponse.getBody());
     }
 
     @Test

--- a/core/src/test/java/greencity/security/controller/OwnSecurityControllerTest.java
+++ b/core/src/test/java/greencity/security/controller/OwnSecurityControllerTest.java
@@ -1,10 +1,8 @@
 package greencity.security.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import greencity.ModelUtils;
-import greencity.security.dto.ownsecurity.EmployeeSignUpDto;
-import greencity.security.dto.ownsecurity.OwnRestoreDto;
-import greencity.security.dto.ownsecurity.OwnSignInDto;
-import greencity.security.dto.ownsecurity.OwnSignUpDto;
+import greencity.security.dto.ownsecurity.*;
 import greencity.security.service.OwnSecurityService;
 import greencity.security.service.PasswordRecoveryService;
 import greencity.security.service.VerifyEmailService;
@@ -16,9 +14,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import static org.mockito.Mockito.verify;
+
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -141,9 +143,9 @@ class OwnSecurityControllerTest {
               "confirmPassword": "String123=",
               "password": "String124=",
               "token": "12345",
-              "isUbs": "false"
-            }\
-            """;
+                                      "isUbs": "false"
+                                    }\
+                                    """;
 
         OwnRestoreDto form = new OwnRestoreDto("String124=", "String123=", "12345", false);
 
@@ -154,6 +156,60 @@ class OwnSecurityControllerTest {
 
         verify(passwordRecoveryService).updatePasswordUsingToken(form);
     }
+    @Test
+    void setPasswordTest_Success() throws Exception {
+        String jsonContent = """
+        {
+            "password": "newPassword123=",
+            "confirmPassword": "newPassword123="
+        }
+        """;
+
+        setupMockSecurityContext();
+        doNothing().when(ownSecurityService).setPassword(any(SetPasswordDto.class), anyString());
+
+        mockMvc.perform(post(LINK + "/set-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonContent))
+                .andExpect(status().isCreated());
+
+        verify(ownSecurityService).setPassword(any(SetPasswordDto.class), anyString());
+    }
+
+    @Test
+    void resetPasswordTest() throws Exception {
+        String content = """
+            {
+              "currentPassword": "CurrentString123=",
+              "newPassword": "NewString123=",
+              "confirmPassword": "NewString123="
+            }\
+            """;
+
+        ResetPasswordDto dto = ModelUtils.getObjectMapper().readValue(content, ResetPasswordDto.class);
+
+        setupMockSecurityContext();
+        doNothing().when(ownSecurityService).resetPassword(dto, "test@mail.com");
+
+        mockMvc.perform(post(LINK+ "/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content))
+                .andExpect(status().isOk());
+
+        verify(ownSecurityService).resetPassword(dto, "test@mail.com");
+    }
+
+    private void setupMockSecurityContext() {
+        Authentication authentication = mock(Authentication.class);
+        SecurityContext securityContext = mock(SecurityContext.class);
+
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        lenient().when(authentication.getName()).thenReturn("test@mail.com");
+
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+
 
 //    @Test
 //    void updatePasswordTest() throws Exception {

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -16,6 +16,7 @@ public final class ErrorMessage {
     public static final String EMAIL_TOKEN_EXPIRED = "User late with verify. Token is invalid.";
     public static final String PASSWORD_RESTORE_LINK_ALREADY_SENT =
         "Password restore link already sent, please check your email: ";
+    public static final String NEW_PASSWORD_SAME_AS_OLD = "Password same as old password";
     public static final String REFRESH_TOKEN_NOT_VALID = "Refresh token not valid!";
     public static final String BAD_PASSWORD = "Bad password";
     public static final String USER_ALREADY_REGISTERED_WITH_THIS_EMAIL = "User with this email is already registered";

--- a/service-api/src/main/java/greencity/exception/exceptions/PasswordSameAsOldException.java
+++ b/service-api/src/main/java/greencity/exception/exceptions/PasswordSameAsOldException.java
@@ -1,0 +1,8 @@
+package greencity.exception.exceptions;
+
+public class PasswordSameAsOldException extends RuntimeException {
+
+    public PasswordSameAsOldException(String message) {
+        super(message);
+    }
+}

--- a/service-api/src/main/java/greencity/security/dto/ownsecurity/ResetPasswordDto.java
+++ b/service-api/src/main/java/greencity/security/dto/ownsecurity/ResetPasswordDto.java
@@ -1,0 +1,25 @@
+package greencity.security.dto.ownsecurity;
+
+import greencity.annotations.PasswordValidation;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@EqualsAndHashCode
+@AllArgsConstructor
+public class ResetPasswordDto {
+    @NotBlank
+    @PasswordValidation
+    private String currentPassword;
+
+    @NotBlank
+    @PasswordValidation
+    private String newPassword;
+
+    @NotBlank
+    @PasswordValidation
+    private String confirmPassword;
+}

--- a/service-api/src/main/java/greencity/security/service/OwnSecurityService.java
+++ b/service-api/src/main/java/greencity/security/service/OwnSecurityService.java
@@ -88,4 +88,6 @@ public interface OwnSecurityService {
      * @param email {@link String} email of user.
      */
     void setPassword(SetPasswordDto dto, String email);
+
+    void resetPassword(ResetPasswordDto dto, String email);
 }


### PR DESCRIPTION
As a registered user I want to be able to change my password.

Acceptance Criteria:

Provided user clicks on "Change password" button in User settings, system shall display the following input fields below the button:
a. "Current password"
b. "New password"
c. "Confirm password"

Criteria for a new password shall be the same as in https://github.com/Board-Project-Stage/ProjectStage_Team2_August/issues/29.

GIVEN user entered incorrect current password, WHEN he presses "Save" button, THEN system shall
a. highlight the input field red
b. display a textual error message "Incorrect password" above the input field

GIVEN new password does not match security criteria, WHEN user presses "Save" button, THEN system shall display
a. highlight the input field red
b. display a textual error message "Password does not match security criteria" above the input field

GIVEN confirm password does not match new password, WHEN user presses "Save" button, THEN system shall
a. highlight the input field red
b. display a textual error message "Password does not match" above the input field